### PR TITLE
Fix error in main.go that was missed

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ import (
 func main() {
     // Create a new easytemplate engine.
     engine := easytemplate.New()
-
+    data := 0
     // Start the engine from a javascript entrypoint.
     err := engine.RunScript("main.js", data)
     if err != nil {


### PR DESCRIPTION
The example had `data` undeclared.  Since it doesn't appear to be used, I just defined it as zero.